### PR TITLE
Mock main

### DIFF
--- a/public/mock/main.html
+++ b/public/mock/main.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="ja">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>task-board</title>
+
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+</head>
+<body>
+    <nav class="navbar navbar-default">
+        <div class="container-fluid">
+            <div class="navbar-header">
+                <a class="navbar-brand" href="#">task-board</a>
+            </div>
+            <div class="navbar-right">
+                <button type="button" class="btn btn-default navbar-btn">Add a list</button>
+            </div>
+        </div>
+    </nav>
+    <div class="container">
+        <div class="page-header">
+            <h1>Board名</h1>
+        </div>
+        <div class="row">
+            <div class="col-md-4">
+                <div class="panel panel-default">
+                    <div class="panel-heading">グループ1</div>
+                    <div class="list-group">
+                        <a href="#" class="list-group-item">タスク1</a>
+                        <a href="#" class="list-group-item">タスク2</a>
+                        <a href="#" class="list-group-item">タスク3</a>
+                    </div>
+                    <div class="panel-footer"><a href="#">Add a card...</a></div>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="panel panel-default">
+                    <div class="panel-heading">グループ2</div>
+                    <div class="list-group">
+                        <a href="#" class="list-group-item">タスク4</a>
+                        <a href="#" class="list-group-item">タスク5</a>
+                    </div>
+                    <div class="panel-footer"><a href="#">Add a card...</a></div>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="panel panel-default">
+                    <div class="panel-heading">グループ3</div>
+                    <div class="list-group">
+                        <a href="#" class="list-group-item">タスク6</a>
+                    </div>
+                    <div class="panel-footer"><a href="#">Add a card...</a></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</doby>
+</html>

--- a/public/mock/main.html
+++ b/public/mock/main.html
@@ -18,7 +18,7 @@
                 <a class="navbar-brand" href="#">task-board</a>
             </div>
             <div class="navbar-right">
-                <button type="button" class="btn btn-default navbar-btn">Add a list</button>
+                <button type="button" data-toggle="modal" data-target="#groupModal" class="btn btn-default navbar-btn">Add a group</button>
             </div>
         </div>
     </nav>
@@ -26,38 +26,107 @@
         <div class="page-header">
             <h1>Board名</h1>
         </div>
+        <div class="alert alert-success">
+        	<button class="close" data-dismiss="alert">&times;</button>
+        	success系メッセージ
+        </div>
+        <div class="alert alert-danger">
+        	<button class="close" data-dismiss="alert">&times;</button>
+        	error系メッセージ
+        </div>
         <div class="row">
             <div class="col-md-4">
                 <div class="panel panel-default">
-                    <div class="panel-heading">グループ1</div>
-                    <div class="list-group">
-                        <a href="#" class="list-group-item">タスク1</a>
-                        <a href="#" class="list-group-item">タスク2</a>
-                        <a href="#" class="list-group-item">タスク3</a>
+                    <div class="panel-heading">
+                        <a href="#groupModal" data-toggle="modal"><span class="glyphicon glyphicon-cog close" aria-hidden="true"></span></a>
+                        グループ1
                     </div>
-                    <div class="panel-footer"><a href="#">Add a card...</a></div>
+                    <div class="list-group">
+                        <a href="#taskModal" data-toggle="modal" class="list-group-item">タスク1</a>
+                        <a href="#taskModal" data-toggle="modal" class="list-group-item">タスク2</a>
+                        <a href="#taskModal" data-toggle="modal" class="list-group-item">タスク3</a>
+                    </div>
+                    <div class="panel-footer"><a href="#taskModal" data-toggle="modal">Add a task...</a></div>
                 </div>
             </div>
             <div class="col-md-4">
                 <div class="panel panel-default">
-                    <div class="panel-heading">グループ2</div>
-                    <div class="list-group">
-                        <a href="#" class="list-group-item">タスク4</a>
-                        <a href="#" class="list-group-item">タスク5</a>
+                    <div class="panel-heading">
+                        <a href="#groupModal" data-toggle="modal"><span class="glyphicon glyphicon-cog close" aria-hidden="true"></span></a>
+                        グループ2
                     </div>
-                    <div class="panel-footer"><a href="#">Add a card...</a></div>
+                    <div class="list-group">
+                        <a href="#taskModal" data-toggle="modal" class="list-group-item">タスク4</a>
+                        <a href="#taskModal" data-toggle="modal" class="list-group-item">タスク5</a>
+                    </div>
+                    <div class="panel-footer"><a href="#taskModal" data-toggle="modal">Add a task...</a></div>
                 </div>
             </div>
             <div class="col-md-4">
                 <div class="panel panel-default">
-                    <div class="panel-heading">グループ3</div>
-                    <div class="list-group">
-                        <a href="#" class="list-group-item">タスク6</a>
+                    <div class="panel-heading">
+                        <a href="#groupModal" data-toggle="modal"><span class="glyphicon glyphicon-cog close" aria-hidden="true"></span></a>
+                        グループ3
                     </div>
-                    <div class="panel-footer"><a href="#">Add a card...</a></div>
+                    <div class="list-group">
+                        <a href="#taskModal" data-toggle="modal" class="list-group-item">タスク6</a>
+                    </div>
+                    <div class="panel-footer"><a href="#taskModal" data-toggle="modal">Add a task...</a></div>
                 </div>
             </div>
         </div>
     </div>
+
+    <div class="modal fade" id="taskModal" tabindex="-1" role="dialog" aria-labelledby="taskModalLabel">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title" id="taskModalLabel">Task</h4>
+                </div>
+                <div class="modal-body">
+                    <form>
+                        <div class="form-group">
+                            <label for="subject" class="control-label">タスク名:</label>
+                            <input type="text" class="form-control" id="subject">
+                        </div>
+                        <div class="form-group">
+                            <label for="body" class="control-label">内容:</label>
+                            <textarea class="form-control" id="body"></textarea>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-primary">Save</button>
+                    <button type="button" class="btn btn-danger">Delete</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+
+    <div class="modal fade" id="groupModal" tabindex="-1" role="dialog" aria-labelledby="groupModalLabel">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title" id="groupModalLabel">Group</h4>
+                </div>
+                <div class="modal-body">
+                    <form>
+                        <div class="form-group">
+                            <label for="subject" class="control-label">グループ名:</label>
+                            <input type="text" class="form-control" id="subject">
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-primary">Save</button>
+                    <button type="button" class="btn btn-danger">Delete</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
 </doby>
 </html>


### PR DESCRIPTION
当初言ってたgoogle material design liteは、cardをグループ化するやり方がよく分からなかったので無難にbootstrapを使ってみました。
- ダイアログの「Delete」ボタンは新規登録時は非表示にするような制御を入れる想定です
- そもそもDeleteするのか？(Archive？)は別途検討しましょう
- グループが4つ以上の時のレイアウトはまだ考慮してません
- タスク・グループの並べ替えはドラッグアンドドロップで行う想定ですが、formもあった方がいい？

取り急ぎの補足や懸念事項はこんなところです。その他気づいた点があればお知らせください〜
