### PR TITLE
Modify model_specs (#73)

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -5,17 +5,11 @@ class Board < ActiveRecord::Base
 
   private
 
-  def default_priority
-    self.priority ||= (self.class.maximum(:priority) || 0).next
-  end
-
-  def shift_other_priorities
-    return default_priority if self.priority.blank?
+  def adjust_priority
+    self.priority = (Board.maximum(:priority) || 0).next if self.priority.blank?
     return if Board.find_by(priority: self.priority).blank?
-    Board.where(
-      'priority >= ?', self.priority
-    ).update_all(
-      'priority = priority + 1'
-    )
+    Board.where('priority >= ?', self.priority)
+      .where.not(id: self.id)
+      .update_all('priority = priority + 1')
   end
 end

--- a/app/models/concerns/card_behavior.rb
+++ b/app/models/concerns/card_behavior.rb
@@ -5,8 +5,7 @@ module CardBehavior
     validates :subject, presence: true
     validates :priority, numericality: {only_integer: true}, allow_blank: true
 
-    before_create :default_priority
-    before_update :shift_other_priorities
+    before_save :adjust_priority
 
     scope :prior, -> { order(:priority, updated_at: :desc) }
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,19 +5,15 @@ class Task < ActiveRecord::Base
 
   private
 
-  def default_priority
-    self.priority ||= (self.class.where(group_id: group_id).maximum(:priority) || 0).next
-  end
-
-  def shift_other_priorities
-    return default_priority if self.priority.blank?
-    return if Task.find_by(priority: self.priority, group_id: self.group_id).blank?
-    Task.where(
-      'priority >= ?', self.priority
-    ).where(
-      group_id: self.group_id
-    ).update_all(
-      'priority = priority + 1'
-    )
+  def adjust_priority
+    if self.priority.blank?
+      self.priority = (Task.where(group_id: self.group_id).maximum(:priority) || 0).next
+      return
+    end
+    return if Task.find_by(group_id: self.group_id, priority: self.priority).blank?
+    Task.where(group_id: self.group_id)
+      .where('priority >= ?', self.priority)
+      .where.not(id: self.id)
+      .update_all('priority = priority + 1')
   end
 end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -1,37 +1,124 @@
 require 'rails_helper'
 
 RSpec.describe Board, type: :model do
-  before do
-    @board = Board.new(
-      subject: 'Lucky board',
-      priority: 1000,
-    )
+  describe 'validation' do
+    let(:board) { build(:board, subject: subject, priority: priority) }
+    let(:subject) { 'happy board' }
+    let(:priority) { 1 }
+
+    context 'when valid' do
+      it { expect(board).to respond_to(:subject) }
+      it { expect(board).to respond_to(:priority) }
+
+      it { expect(board).to be_valid }
+    end
+
+    context 'when subject is not present' do
+      let(:subject) { '' }
+      it { expect(board).not_to be_valid }
+    end
+
+    context 'when priority is not numeric' do
+      let(:priority) { 'a' }
+      it { expect(board).not_to be_valid }
+    end
+
+    context 'when priority is numeric but not integer' do
+      let(:priority) { 10.1 }
+      it { expect(board).not_to be_valid }
+    end
+
+    context 'when priority is not present' do
+      let(:priority) { nil }
+      it { expect(board).to be_valid }
+    end
   end
 
-  subject { @board }
+  describe 'scope' do
+    let(:boards) { create_list(:board, 3, priority: 2, updated_at: now) }
+    let(:now) { Time.now }
 
-  it { should respond_to(:subject) }
-  it { should respond_to(:priority) }
-
-  it { should be_valid }
-
-  describe 'when subject is not present' do
-    before { @board.subject = '' }
-    it { should_not be_valid }
+    it 'returns boards order by priority asc, updated_at desc' do
+      boards.first.updated_at = now - 1.day
+      boards.first.save
+      Board.where(id: [boards.first.id, boards.second.id]).update_all(priority: 1)
+      actual = Board.prior
+      expect(actual.first).to eq boards.second
+      expect(actual.second).to eq boards.first
+      expect(actual.third).to eq boards.third
+    end
   end
 
-  describe 'when priority is not numeric' do
-    before { @board.priority = 'a' }
-    it { should_not be_valid }
+  describe 'priority when created' do
+    let!(:board) { create(:board, priority: 1001) }
+    let(:creates) { attributes_for(:board, subject: 'a', priority: priority) }
+
+    context 'if priority is not present' do
+      let(:priority) { nil }
+
+      it 'sets max existent value + 1' do
+        Board.create(creates)
+        expect(Board.find_by(subject: 'a').priority).to eq board.priority + 1
+        expect(Board.find(board.id).priority).to eq board.priority
+      end
+    end
+
+    context 'if priority is present' do
+      context 'when same priority is not exist' do
+        let(:priority) { 999 }
+
+        it 'sets given value' do
+          Board.create(creates)
+          expect(Board.find_by(subject: 'a').priority).to eq priority
+          expect(Board.find(board.id).priority).to eq board.priority
+        end
+      end
+
+      context 'when same priority is exist' do
+        let(:priority) { board.priority }
+
+        it 'sets given value and increment existent value' do
+          Board.create(creates)
+          expect(Board.find_by(subject: 'a').priority).to eq priority
+          expect(Board.find(board.id).priority).to eq board.priority + 1
+        end
+      end
+    end
   end
 
-  describe 'when priority is numeric but not integer' do
-    before { @board.priority = 10.1 }
-    it { should_not be_valid }
-  end
+  describe 'priority when updated' do
+    before do
+      create_list(:board, 2)
+      Board.update_all(priority: 1001) # before_saveフィルタでincrementされないように#update_allする
+      @boards = Board.all
+    end
 
-  describe 'when priority is not present' do
-    before { @board.priority = '' }
-    it { should be_valid }
+    context 'if priority is not present' do
+      it 'sets max existent value + 1' do
+        @boards.first.priority = nil
+        @boards.first.save
+        expect(Board.find(@boards.first.id).priority).to eq @boards.second.priority + 1
+      end
+    end
+
+    context 'if priority is present' do
+      context 'when same priority is not exist' do
+        it 'sets given value' do
+          @boards.first.priority = 999
+          @boards.first.save
+          expect(Board.find(@boards.first.id).priority).to eq 999
+          expect(Board.find(@boards.second.id).priority).to eq @boards.second.priority
+        end
+      end
+
+      context 'when same priority is exist' do
+        it 'sets given value and increment existent value' do
+          @boards.first.subject = 'lucky board'
+          @boards.first.save
+          expect(Board.find(@boards.first.id).priority).to eq @boards.first.priority
+          expect(Board.find(@boards.second.id).priority).to eq @boards.first.priority + 1
+        end
+      end
+    end
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,37 +1,176 @@
 require 'rails_helper'
 
 RSpec.describe Group, type: :model do
-  before do
-    @group = Group.new(
-      subject: 'Fortune group',
-      priority: 10,
-    )
+  describe 'validation' do
+    let(:group) { build(:group, subject: subject, priority: priority) }
+    let(:subject) { 'happy group' }
+    let(:priority) { 1 }
+
+    context 'when valid' do
+      it { expect(group).to respond_to(:subject) }
+      it { expect(group).to respond_to(:priority) }
+      it { expect(group).to respond_to(:board_id) }
+
+      it { expect(group).to be_valid }
+    end
+
+    context 'when subject is not present' do
+      let(:subject) { '' }
+      it { expect(group).not_to be_valid }
+    end
+
+    context 'when priority is not numeric' do
+      let(:priority) { 'a' }
+      it { expect(group).not_to be_valid }
+    end
+
+    context 'when priority is numeric but not integer' do
+      let(:priority) { 10.1 }
+      it { expect(group).not_to be_valid }
+    end
+
+    context 'when priority is not present' do
+      let(:priority) { nil }
+      it { expect(group).to be_valid }
+    end
   end
 
-  subject { @group }
+  describe 'scope' do
+    let(:groups) { create_list(:group, 3, priority: 2, updated_at: now) }
+    let(:now) { Time.new }
 
-  it { should respond_to(:subject) }
-  it { should respond_to(:priority) }
-
-  it { should be_valid }
-
-  describe 'when subject is not present' do
-    before { @group.subject = '' }
-    it { should_not be_valid }
+    it 'returns groups order by priority asc, updated_at desc' do
+      groups.first.updated_at = now - 1.day
+      groups.first.save
+      Group.where(id: [groups.first.id, groups.second.id]).update_all(priority: 1)
+      actual = Group.prior
+      expect(actual.first).to eq groups.second
+      expect(actual.second).to eq groups.first
+      expect(actual.third).to eq groups.third
+    end
   end
 
-  describe 'when priority is not numeric' do
-    before { @group.priority = 'a' }
-    it { should_not be_valid }
+  describe 'priority when created' do
+    let!(:group) { create(:group, priority: 1001) }
+    let(:creates) { attributes_for(:group, subject: 'a', priority: priority, board_id: board_id) }
+
+    context 'if priority is not present' do
+      let(:priority) { nil }
+
+      context 'on same board' do
+        let(:board_id) { group.board_id }
+
+        it 'sets max existent value + 1' do
+          Group.create(creates)
+          expect(Group.find_by(subject: 'a').priority).to eq group.priority + 1
+          expect(Group.find(group.id).priority).to eq group.priority
+        end
+      end
+
+      context 'on another board' do
+        let(:board_id) { group.board_id + 1 }
+
+        it 'sets 1' do
+          Group.create(creates)
+          expect(Group.find_by(subject: 'a').priority).to eq 1
+        end
+      end
+    end
+
+    context 'if priority is present' do
+      context 'when same priority is not exist' do
+        let(:priority) { 999 }
+        let(:board_id) { group.board_id }
+
+        it 'sets given value' do
+          Group.create(creates)
+          expect(Group.find_by(subject: 'a').priority).to eq priority
+          expect(Group.find(group.id).priority).to eq group.priority
+        end
+
+        context 'when same priority is exist' do
+          let(:priority) { group.priority }
+
+          context 'on same board' do
+            let(:board_id) { group.board_id }
+
+            it 'sets given value and increment existent value' do
+              Group.create(creates)
+              expect(Group.find_by(subject: 'a').priority).to eq priority
+              expect(Group.find(group.id).priority).to eq group.priority + 1
+            end
+          end
+
+          context 'on another board' do
+            let(:board_id) { group.board_id + 1 }
+
+            it 'sets given value and NOT increment existent value' do
+              Group.create(creates)
+              expect(Group.find_by(subject: 'a').priority).to eq priority
+              expect(Group.find(group.id).priority).to eq group.priority
+            end
+          end
+        end
+      end
+    end
   end
 
-  describe 'when priority is numeric but not integer' do
-    before { @group.priority = 10.1 }
-    it { should_not be_valid }
-  end
+  describe 'priority when update' do
+    before do
+      create_list(:group, 2, board_id: 1)
+      Group.update_all(priority: 1001)
+      @groups = Group.all
+    end
 
-  describe 'when priority is not present' do
-    before { @group.priority = '' }
-    it { should be_valid }
+    context 'if priority is not present' do
+      context 'on same board' do
+        it 'sets max existent value + 1' do
+          @groups.first.priority = nil
+          @groups.first.save
+          expect(Group.find(@groups.first.id).priority).to eq @groups.second.priority + 1
+        end
+      end
+
+      context 'on another board' do
+        it 'sets 1' do
+          @groups.first.board_id = 2
+          @groups.first.priority = nil
+          @groups.first.save
+          expect(Group.find(@groups.first.id).priority).to eq 1
+        end
+      end
+    end
+
+    context ' if priority is present' do
+      context 'when same priority is not exist' do
+        it 'sets given value' do
+          @groups.first.priority = 999
+          @groups.first.save
+          expect(Group.find(@groups.first.id).priority).to eq 999
+          expect(Group.find(@groups.second.id).priority).to eq @groups.second.priority
+        end
+
+        context 'when same priority is exist' do
+          context 'on same board' do
+            it 'sets given value and increment existent vale' do
+              @groups.first.subject = 'lucky group'
+              @groups.first.save
+              expect(Group.find(@groups.first.id).priority).to eq @groups.first.priority
+              expect(Group.find(@groups.second.id).priority).to eq @groups.first.priority + 1
+            end
+          end
+
+          context 'on another group' do
+            it 'sets given value and NOT increment existent value' do
+              @groups.first.board_id = 2
+              @groups.first.subject = 'lucky group'
+              @groups.first.save
+              expect(Group.find(@groups.first.id).priority).to eq @groups.first.priority
+              expect(Group.find(@groups.second.id).priority).to eq @groups.second.priority
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,39 +1,178 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-  before do
-    @task = Task.new(
-      subject: 'Happy task',
-      body: 'Create something new',
-      priority: 100,
-    )
+  describe 'validation' do
+    let(:task) { build(:task, subject: subject, priority: priority) }
+    let(:subject) { 'happy task' }
+    let(:priority) { 1 }
+
+    context 'when valid' do
+      it { expect(task).to respond_to(:subject) }
+      it { expect(task).to respond_to(:body) }
+      it { expect(task).to respond_to(:priority) }
+      it { expect(task).to respond_to(:group_id) }
+
+      it { expect(task).to be_valid }
+    end
+
+    context 'when subject is not present' do
+      let(:subject) { '' }
+      it { expect(task).not_to be_valid }
+    end
+
+    context 'when priority is not numeric' do
+      let(:priority) { 'a' }
+      it { expect(task).not_to be_valid }
+    end
+
+    context 'when priority is numeric but not integer' do
+      let(:priority) { 100.1 }
+      it { expect(task).not_to be_valid }
+    end
+
+    describe 'when priority is not present' do
+      let(:priority) { nil }
+      it { expect(task).to be_valid }
+    end
   end
 
-  subject { @task }
+  describe 'scope' do
+    let(:tasks) { create_list(:task, 3, priority: 2, updated_at: now) }
+    let(:now) { Time.new }
 
-  it { should respond_to(:subject) }
-  it { should respond_to(:body) }
-  it { should respond_to(:priority) }
-
-  it { should be_valid }
-
-  describe 'when subject is not present' do
-    before { @task.subject = '' }
-    it { should_not be_valid }
+    it 'returns tasks order by priority asc, updated_at desc' do
+      tasks.first.updated_at = now - 1.day
+      tasks.first.save
+      Task.where(id: [tasks.first.id, tasks.second.id]).update_all(priority: 1)
+      actual = Task.prior
+      expect(actual.first).to eq tasks.second
+      expect(actual.second).to eq tasks.first
+      expect(actual.third).to eq tasks.third
+    end
   end
 
-  describe 'when priority is not numeric' do
-    before { @task.priority = 'a' }
-    it { should_not be_valid }
+  describe 'priority when created' do
+    let(:task) { create(:task, priority: 1001) }
+    let(:creates) { attributes_for(:task, subject: 'a', priority: priority, group_id: group_id) }
+
+    context 'if priority is not present' do
+      let(:priority) { nil }
+
+      context 'on same group' do
+        let(:group_id) { task.group_id }
+
+        it 'sets max existent value + 1' do
+          Task.create(creates)
+          expect(Task.find_by(subject: 'a').priority).to eq task.priority + 1
+          expect(Task.find(task.id).priority).to eq task.priority
+        end
+      end
+
+      context 'on another board' do
+        let(:group_id) { task.group_id + 1 }
+
+        it 'sets 1' do
+          Task.create(creates)
+          expect(Task.find_by(subject: 'a').priority).to eq 1
+        end
+      end
+
+      context 'if priority is present' do
+        context 'when same priority is not exist' do
+          let(:priority) { 999 }
+          let(:group_id) { task.group_id }
+
+          it 'sets given value' do
+            Task.create(creates)
+            expect(Task.find_by(subject: 'a').priority).to eq priority
+            expect(Task.find(task.id).priority).to eq task.priority
+          end
+
+          context 'when same priority is exist' do
+            let(:priority) { task.priority }
+
+            context 'on same group' do
+              let(:group_id) { task.group_id }
+
+              it 'sets given value and increment existent value' do
+                Task.create(creates)
+                expect(Task.find_by(subject: 'a').priority).to eq priority
+                expect(Task.find(task.id).priority).to eq task.priority + 1
+              end
+            end
+
+            context 'on another group' do
+              let(:group_id) { task.group_id + 1 }
+
+              it 'sets given value and NOT increment existent value' do
+                Task.create(creates)
+                expect(Task.find_by(subject: 'a').priority).to eq priority
+                expect(Task.find(task.id).priority).to eq task.priority
+              end
+            end
+          end
+        end
+      end
+    end
   end
 
-  describe 'when priority is numeric but not integer' do
-    before { @task.priority = 100.1 }
-    it { should_not be_valid }
-  end
+  describe 'priority when update' do
+    before do
+      create_list(:task, 2, group_id: 1)
+      Task.update_all(priority: 1001)
+      @tasks = Task.all
+    end
 
-  describe 'when priority is not present' do
-    before { @task.priority = '' }
-    it { should be_valid }
+    context 'if priority is not present' do
+      context 'on same group'do
+        it 'sets max existent value + 1' do
+          @tasks.first.priority = nil
+          @tasks.first.save
+          expect(Task.find(@tasks.first.id).priority).to eq @tasks.second.priority + 1
+        end
+      end
+
+      context 'on another group' do
+        it 'sets 1' do
+          @tasks.first.group_id = 2
+          @tasks.first.priority = nil
+          @tasks.first.save
+          expect(Task.find(@tasks.first.id).priority).to eq 1
+        end
+      end
+    end
+
+    context 'if priority is present' do
+      context 'when same priority is not exist' do
+        it 'sets given value' do
+          @tasks.first.priority = 999
+          @tasks.first.save
+          expect(Task.find(@tasks.first.id).priority).to eq 999
+          expect(Task.find(@tasks.second.id).priority).to eq @tasks.second.priority
+        end
+
+        context 'when same priority is exist' do
+          context 'on same group' do
+            it 'sets given value and increment existent value' do
+              @tasks.first.subject = 'lucky task'
+              @tasks.first.save
+              expect(Task.find(@tasks.first.id).priority).to eq @tasks.first.priority
+              expect(Task.find(@tasks.second.id).priority).to eq @tasks.first.priority + 1
+            end
+          end
+
+          context 'when another group' do
+            it 'sets given value and NOT increment existent valud' do
+              @tasks.first.group_id = 2
+              @tasks.first.subject = 'lucky task'
+              @tasks.first.save
+              expect(Task.find(@tasks.first.id).priority).to eq @tasks.first.priority
+              expect(Task.find(@tasks.second.id).priority).to eq @tasks.first.priority
+            end
+          end
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
いや～難産でし。
- (重複priorityが存在する場合に)
  
  > 並べ替えをせずに編集した場合でもpriority値がインクリメントされてしまう

に関しては、いったん「仕様」とさせてくださいw
(重複priority解消のためのトリガーのひとつとみなす、という考え方)
あ、編集対象自身のpriorityはインクリメントされず、それ以下のpriorityを持つ他オブジェクトだけインクリメントされるようにはしたつもりっす。
