### PR TITLE
Fix autosaving duplicative members (#116)

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ActiveRecord::Base
-  has_many :members
+  has_many :members, dependent: :destroy
   has_many :users, through: :members
 
   belongs_to :user, foreign_key: :created_by
@@ -19,6 +19,13 @@ class Item < ActiveRecord::Base
   scope :peers, ->(parent_id) { where(parent_id: parent_id) }
 
   private
+
+  def autosave_associated_records_for_members
+    members.each do |m|
+      member = Member.find_or_initialize_by(item_id: self.id, user_id: m.user_id)
+      member.save!
+    end
+  end
 
   def adjust_priority
     if self.priority.blank?

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -2,4 +2,29 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
   it_behaves_like 'item behavior'
+
+  describe 'member association' do
+    let!(:task) { create(:task, members: [create(:member)]) }
+
+    context 'when add members' do
+      it 'not duplicates' do
+        old = task.members.size
+        task.update(
+          members: [
+            Member.new(item_id: task.id, user_id: task.members.first.id, is_owner: true),
+            Member.new(item_id: task.id, user_id: task.members.first.id + 1)
+          ]
+        )
+        expect(task.members.size).to eq old + 1
+        expect(task.members.first.user_id).not_to eq task.members.second.user_id
+      end
+    end
+
+    context 'when parent has destroyed' do
+      it 'destroys members belongs to' do
+        Task.find(task.id).destroy
+        expect(Member.find_by(item_id: task.id)).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
- 同一ボード／タスクでメンバーが重複登録されないようにした
- ボード／タスクを削除したら紐付くメンバーも削除

よろしくお願いします!
