### PR TITLE
Implement member removal (#120)

### DIFF
--- a/app/controllers/api/v1/boards_controller.rb
+++ b/app/controllers/api/v1/boards_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::BoardsController < Api::V1::ApplicationController
   def resource_params
     params.require(model_name.underscore.intern).permit(
       *@model.column_names.map(&:intern), :user_id,
-      members_attributes: [:item_id, :user_id, :is_owner]
+      members_attributes: [:item_id, :user_id, :is_owner, :release]
     )
   end
 

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -24,7 +24,7 @@ class Api::V1::GroupsController < Api::V1::ApplicationController
   def resource_params
     params.require(model_name.underscore.intern).permit(
       *@model.column_names.map(&:intern), :user_id, :board_id,
-      members_attributes: [:item_id, :user_id, :is_owner]
+      members_attributes: [:item_id, :user_id, :is_owner, :release]
     )
   end
 

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::TasksController < Api::V1::ApplicationController
   def resource_params
     params.require(model_name.underscore.intern).permit(
       *@model.column_names.map(&:intern), :user_id, :group_id,
-      members_attributes: [:item_id, :user_id, :is_owner]
+      members_attributes: [:item_id, :user_id, :is_owner, :release]
     )
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -22,6 +22,10 @@ class Item < ActiveRecord::Base
 
   def autosave_associated_records_for_members
     members.each do |m|
+      if m.release
+        Member.destroy_all(item_id: m.item_id, user_id: m.user_id)
+        next
+      end
       member = Member.find_or_initialize_by(item_id: self.id, user_id: m.user_id)
       member.save!
     end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,4 +1,6 @@
 class Member < ActiveRecord::Base
   belongs_to :item
   belongs_to :user
+
+  attr_accessor :release
 end

--- a/spec/requests/api/v1/boards_spec.rb
+++ b/spec/requests/api/v1/boards_spec.rb
@@ -156,6 +156,27 @@ RSpec.describe 'Api::V1::Boards', type: :request do
         }.not_to change(Board, :count)
       end
     end
+
+    context 'with _destroy flag on member' do
+      let!(:member) { create(:member, item_id: board.id) }
+      let!(:params) do
+        {
+          board: {
+            id: board.id,
+            members_attributes: [
+              { item_id: nil, user_id: @user.id },
+              { item_id: nil, user_id: member.user_id, release: '1' }
+            ]
+          }
+        }
+      end
+
+      it 'removes member' do
+        expect { is_expected.to eq 200 }.to change(Member, :count).by(+ 1 - 1)
+        expect(Member.count).to eq 1
+        expect(Member.first.user_id).to eq @user.id
+      end
+    end
   end
 
   describe 'PATCH /api/v1/boards/:id/dryrun' do

--- a/spec/requests/api/v1/tasks_spec.rb
+++ b/spec/requests/api/v1/tasks_spec.rb
@@ -176,6 +176,27 @@ RSpec.describe 'Api::V1::Tasks', type: :request do
         }.not_to change(Task, :count)
       end
     end
+
+    context 'with _destroy flag on member' do
+      let!(:member) { create(:member, item_id: task.id) }
+      let!(:params) do
+        {
+          task: {
+            id: task.id,
+            members_attributes: [
+              { item_id: nil, user_id: @user.id },
+              { item_id: nil, user_id: member.user_id, release: '1' }
+            ]
+          }
+        }
+      end
+
+      it 'removes member' do
+        expect { is_expected.to eq 200 }.to change(Member, :count).by(+ 1 - 1)
+        expect(Member.count).to eq 1
+        expect(Member.first.user_id).to eq @user.id
+      end
+    end
   end
 
   describe 'PATCH /api/v1/tasks/:id/dryrun' do


### PR DESCRIPTION
PATCH時に

``` json
{
  "task": {
    "id": 999,
    "members_attributes": [
      { "user_id": 1, "release": 1 },
      { "user_id": 2 }
    ]
  }
}
```

こんな感じで `release` パラメータを真値で付加したメンバーが削除されます、多分。
