### PR TITLE
Bugfix navbar mobile

### DIFF
--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -2,6 +2,12 @@
 <nav class="navbar navbar-default" data-bind="visible: baseViewModel.user.id() != null">
     <div class="container-fluid">
         <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
             <a class="navbar-brand" href="#">task-board</a>
         </div>
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
@@ -9,7 +15,7 @@
                 <li><button type="button" data-toggle="modal" class="btn btn-default navbar-btn" data-bind="click: openBoardModal">Add a board</button></li>
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                        <img class="avatar-dropdown" data-bind="attr: {src: baseViewModel.user.avatar_url}">
+                        <img class="avatar-dropdown" data-bind="attr: {src: baseViewModel.user.avatar_url}" />
                         <!-- ko text: baseViewModel.user.nickname--><!--/ko-->
                     </a>
                     <ul class="dropdown-menu">

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -2,6 +2,12 @@
 <nav class="navbar navbar-default" data-bind="visible: baseViewModel.user.id() != null">
     <div class="container-fluid">
         <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
             <a class="navbar-brand" href="/">task-board</a>
         </div>
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
@@ -9,7 +15,7 @@
                 <li><button type="button" data-toggle="modal" class="btn btn-default navbar-btn" data-bind="click: openGroupModal">Add a group</button></li>
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                        <img class="avatar-dropdown" data-bind="attr: {src: baseViewModel.user.avatar_url}">
+                        <img class="avatar-dropdown" data-bind="attr: {src: baseViewModel.user.avatar_url}" />
                         <!-- ko text: baseViewModel.user.nickname--><!--/ko-->
                     </a>
                     <ul class="dropdown-menu">

--- a/public/mock/index.html
+++ b/public/mock/index.html
@@ -15,6 +15,12 @@
     <nav class="navbar navbar-default">
         <div class="container-fluid">
             <div class="navbar-header">
+                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
                 <a class="navbar-brand" href="#">task-board</a>
             </div>
             <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
@@ -22,7 +28,7 @@
                     <li><button type="button" data-toggle="modal" data-target="#boardModal" class="btn btn-default navbar-btn">Add a board</button></li>
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                            <img style="height:25px" src="https://avatars.githubusercontent.com/u/1151085?v=3">
+                            <img style="height:25px;" src="https://avatars.githubusercontent.com/u/1151085?v=3" />
                             ユーザ名
                         </a>
                         <ul class="dropdown-menu">

--- a/public/mock/index.html
+++ b/public/mock/index.html
@@ -28,7 +28,7 @@
                     <li><button type="button" data-toggle="modal" data-target="#boardModal" class="btn btn-default navbar-btn">Add a board</button></li>
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                            <img style="height:25px;" src="https://avatars.githubusercontent.com/u/1151085?v=3" />
+                            <img style="height:25px" src="https://avatars.githubusercontent.com/u/1151085?v=3" />
                             ユーザ名
                         </a>
                         <ul class="dropdown-menu">

--- a/public/mock/main.html
+++ b/public/mock/main.html
@@ -15,6 +15,12 @@
     <nav class="navbar navbar-default">
         <div class="container-fluid">
             <div class="navbar-header">
+                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
                 <a class="navbar-brand" href="index.html">task-board</a>
             </div>
             <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">

--- a/public/mock/main.html
+++ b/public/mock/main.html
@@ -28,7 +28,7 @@
                     <li><button type="button" data-toggle="modal" data-target="#groupModal" class="btn btn-default navbar-btn">Add a group</button></li>
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                            <img style="height:25px; float-left" src="https://avatars.githubusercontent.com/u/1151085?v=3">
+                            <img style="height:25px; float-left" src="https://avatars.githubusercontent.com/u/1151085?v=3" />
                             ユーザ名
                         </a>
                         <ul class="dropdown-menu">


### PR DESCRIPTION
先日追加したアバターの影響ではなく、bootstrapでのナビゲーションバーのレスポンシブ対応（ハンバーガーみたいなアイコンクリックしたらメニューが出てくる）部分のhtmlコードがすっぽり抜けてたのが原因でした。コピペするときに「なんだこれ、イラネ」と思って省いてましたよw　勉強になりました。

PCブラウザでもウィンドウの横幅を狭めることで再現可能です。
